### PR TITLE
Add Github release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on: 
+  push:
+    tags:
+    - '*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Pakage Addon
+      run: (cd .. && zip -r PyClone/PyClone.zip PyClone -x '*.git*')
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: "PyClone.zip"
+        token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
This adds a Github Actions workflow that is triggered on the push of a new tag and zips up the repository with `PyClone` as a top-level directory name and adds that archive as an artifact to the release.

One might think that this isn't needed as you can already download the repository source for a release right now. However, that archive has a top-level directory with the name of the tag. E.g. `PyClone-0.4.0` for the tag `0.4.0`. When this archive is installed as an addon via Blender, you will get an error like `Unable to find module 'PyClone-0'`, as the directory name doesn't match the module name.